### PR TITLE
change build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Palapala
 
-Palapala is an collaborative whiteboard browser app powered by [Paper.js](https://paperjs.org) and [ShareDB](https://github.com/share/sharedb). 
-It has a drawing tool set geared towards mathematics instruction. 
+Palapala is an collaborative whiteboard browser app powered by [Paper.js](https://paperjs.org) and [ShareDB](https://github.com/share/sharedb).
+It has a drawing tool set geared towards mathematics instruction.
 In particular it has tools for placing third-party graphing calculator apps onto the canvas, manipulating them collaboratively, and drawing freehand over the inserted graph.
 
 This project was started because I needed a live whiteboard tool for distance learning use during the COVID-19 pandemic and could not locate a suitable Free Software solution.
@@ -13,7 +13,7 @@ Install using `npm` like any Node.js package.
 $ git clone [...]
 $ cd palapala
 $ npm install .
-$ npm build
+$ npm run-script build
 $ npm dist
 ```
 
@@ -24,7 +24,7 @@ If you set `GKEY` and `GSECRET` it will attempt to use Google's OAuth2 API to lo
 
 The start script runs `nodemon  js/server.js` and starts listening on env var PORT || 8000.
 ```
-$ MONGO_URL="[...secret...]" npm start 
+$ MONGO_URL="[...secret...]" npm start
 ```
 Once the server is running direct a browser to `localhost:8000`. You will be redirected to a randomly generated document id `/:id/`
 
@@ -38,4 +38,3 @@ Once the server is running direct a browser to `localhost:8000`. You will be red
 - Multi-page whiteboards
 - SVG export
 - Placing images
-


### PR DESCRIPTION
Re Issue https://github.com/grady/palapala/issues/1, it appears that the README should specify the command

```
npm run-script build
```

instead of

```
npm build
```

The latter issues a warning.  This PR updates the README.